### PR TITLE
fix: Adds a check for workflow availability

### DIFF
--- a/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization-common/report-clients.api.md
+++ b/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization-common/report-clients.api.md
@@ -53,6 +53,8 @@ export interface OrchestratorSlimApi {
   ): Promise<{
     id: string;
   }>;
+  // (undocumented)
+  isWorkflowAvailable(workflowId: string): Promise<boolean>;
 }
 
 // @public (undocumented)
@@ -69,6 +71,8 @@ export class OrchestratorSlimClient implements OrchestratorSlimApi {
   ): Promise<{
     id: string;
   }>;
+  // (undocumented)
+  isWorkflowAvailable(workflowId: string): Promise<boolean>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization-common/report.api.md
+++ b/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization-common/report.api.md
@@ -385,6 +385,8 @@ export interface OrchestratorSlimApi {
   ): Promise<{
     id: string;
   }>;
+  // (undocumented)
+  isWorkflowAvailable(workflowId: string): Promise<boolean>;
 }
 
 // @public (undocumented)
@@ -401,6 +403,8 @@ export class OrchestratorSlimClient implements OrchestratorSlimApi {
   ): Promise<{
     id: string;
   }>;
+  // (undocumented)
+  isWorkflowAvailable(workflowId: string): Promise<boolean>;
 }
 
 // @public (undocumented)

--- a/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization-common/src/clients/orchestrator-slim/OrchestratorSlimApi.ts
+++ b/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization-common/src/clients/orchestrator-slim/OrchestratorSlimApi.ts
@@ -17,6 +17,7 @@ import type { JsonObject } from '@backstage/types';
 
 /** @public */
 export interface OrchestratorSlimApi {
+  isWorkflowAvailable(workflowId: string): Promise<boolean>;
   executeWorkflow<D = JsonObject>(
     workflowId: string,
     workflowInputData: D,

--- a/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization-common/src/clients/orchestrator-slim/OrchestratorSlimClient.ts
+++ b/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization-common/src/clients/orchestrator-slim/OrchestratorSlimClient.ts
@@ -38,6 +38,26 @@ export class OrchestratorSlimClient implements OrchestratorSlimApi {
     this.identityApi = options.identityApi;
   }
 
+  async isWorkflowAvailable(workflowId: string): Promise<boolean> {
+    if (!this.baseUrl) {
+      this.baseUrl = await this.discoveryApi.getBaseUrl('orchestrator');
+    }
+
+    const url = `${this.baseUrl}/v2/workflows/${encodeURIComponent(
+      workflowId,
+    )}/overview`;
+
+    let result = false;
+    try {
+      const response = await this.fetchApi.fetch(url, { method: 'GET' });
+      result = response.ok;
+    } catch {
+      // Carry on...
+    }
+
+    return result;
+  }
+
   /** @public */
   async executeWorkflow<D = JsonObject>(
     workflowId: string,

--- a/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization/src/pages/optimizations-breakdown/OptimizationsBreakdownPage.tsx
+++ b/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization/src/pages/optimizations-breakdown/OptimizationsBreakdownPage.tsx
@@ -50,17 +50,23 @@ export const OptimizationsBreakdownPage = () => {
   const [recommendationTerm, setRecommendationTerm] =
     useState<Interval>('shortTerm');
   const loc = useLocation();
-
+  const { id } = useParams();
   const configApi = useApi(configApiRef);
   const workflowIdRef = useRef<string>(
     configApi.getOptionalString(
       'resourceOptimization.optimizationWorkflowId',
     ) ?? '',
   );
-
-  const { id } = useParams();
+  const orchestratorSlimApi = useApi(orchestratorSlimApiRef);
   const optimizationsApi = useApi(optimizationsApiRef);
   const { value, loading, error } = useAsync(async () => {
+    const isWorkflowAvailable = await orchestratorSlimApi.isWorkflowAvailable(
+      workflowIdRef.current,
+    );
+    if (!isWorkflowAvailable) {
+      workflowIdRef.current = '';
+    }
+
     const apiQuery = {
       path: {
         recommendationId: id!,
@@ -91,7 +97,6 @@ export const OptimizationsBreakdownPage = () => {
     [value],
   );
 
-  const orchestratorSlimApi = useApi(orchestratorSlimApiRef);
   const [_, applyRecommendation] = useAsyncFn(
     async (workflowId: string, workflowData: WorkflowDataSchema) => {
       const payload = await orchestratorSlimApi.executeWorkflow(workflowId, {


### PR DESCRIPTION
Details:
- Fixes an issue that occurred when the workflow was properly configured in the app-config.yaml but the Orchestrator plugin didn't find a workflow with such an ID. This could happen if the workflow was not yet deployed in an OCP cluster or if it is blocked at the Orchestrator's RBAC level (e.g.: users not authorized to access the specific workflow).

Addresses:
- https://issues.redhat.com/browse/FLPATH-2124

Demo:
[FLAPTH-2124.webm](https://github.com/user-attachments/assets/be560cbc-ebf2-4e97-97c7-c60273c424e1)

Signed-off-by: Jonathan Kilzi <jkilzi@redhat.com>
